### PR TITLE
🛠️ upgraded `@typescript-eslint` plugin (8

### DIFF
--- a/src/service-worker/index.test.ts
+++ b/src/service-worker/index.test.ts
@@ -933,11 +933,11 @@ async function expectLogToContain(
       // Reset the mock adapter before this specific test
       mockLoggerAdapter.reset();
 
-      // Trigger two alarms concurrently
-      const alarm1 = handlers.onAlarm!({ name: REFRESH_ALARM_NAME, scheduledTime: Date.now(), periodInMinutes: undefined } as chrome.alarms.Alarm);
-      const alarm2 = handlers.onAlarm!({ name: REFRESH_ALARM_NAME, scheduledTime: Date.now(), periodInMinutes: undefined } as chrome.alarms.Alarm);
+      // Trigger two alarms concurrently (handlers are fire-and-forget, returning void)
+      handlers.onAlarm!({ name: REFRESH_ALARM_NAME, scheduledTime: Date.now(), periodInMinutes: undefined } as chrome.alarms.Alarm);
+      handlers.onAlarm!({ name: REFRESH_ALARM_NAME, scheduledTime: Date.now(), periodInMinutes: undefined } as chrome.alarms.Alarm);
 
-      await Promise.all([alarm1, alarm2]);
+      // Let all async operations complete
       await vi.runAllTimersAsync();
 
       expect(mockApiModule.fetchBtcPrice).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
The upgraded `@typescript-eslint` plugin (8.46.1) now flags `Promise.all()` when passed non-Promise (void) values. The `handlers.onAlarm!()` returns `void`, not a Promise.

### What I fixed
Edited `src/service-worker/index.test.ts` line 936-941: Removed the unused `const alarm1` and `const alarm2` assignments, called the handlers directly without storing return values, and removed the `await Promise.all([alarm1, alarm2])` since the handlers are fire-and-forget. The test now relies solely on `vi.runAllTimersAsync()` to let the internal async operations complete.

### The details
<details>
<summary>Full diagnosis</summary>

Done!

### Root Cause
The upgraded `@typescript-eslint` plugin (8.46.1) now flags `Promise.all()` when passed non-Promise (void) values. The `handlers.onAlarm!()` returns `void`, not a Promise.

### Fix
Edited `src/service-worker/index.test.ts` line 936-941: Removed the unused `const alarm1` and `const alarm2` assignments, called the handlers directly without storing return values, and removed the `await Promise.all([alarm1, alarm2])` since the handlers are fire-and-forget. The test now relies solely on `vi.runAllTimersAsync()` to let the internal async operations complete.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #63 in phrazzld/bitcoin-price-tag*
